### PR TITLE
fix: handle payload === undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ function ignorePath (path, pathsToIgnore) {
 }
 
 function onSendHandler (req, reply, payload, done) {
+  // If payload is undefined
+  if (payload === undefined) {
+    reply.header('content-length', '0')
+    return done(null, null)
+  }
+
   // If is a stream, we remove any header without appending
   // content-length one, and resume it right away
   if (typeof payload.resume === 'function') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -331,3 +331,38 @@ test('Should set a HEAD route for a GET one respecting onSend handlers (single h
     t.strictEqual(res.headers['x-handler-1'], true)
   })
 })
+
+test('Should reply with content-length === 0 when payload undefined', (t) => {
+  t.plan(8)
+  const server = Fastify()
+  server.register(plugin, {})
+
+  server.register(
+    function (fastifyInstance, opts, done) {
+      fastifyInstance.get('/null', (req, reply) => {
+        reply.status(200).send(null)
+      })
+
+      fastifyInstance.get('/undefined', (req, reply) => {
+        reply.status(200).send()
+      })
+
+      done()
+    },
+    { prefix: '/api' }
+  )
+
+  server.inject({ method: 'HEAD', url: '/api/null' }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['content-length'], '4')
+    t.strictEqual(res.body, '')
+  })
+
+  server.inject({ method: 'HEAD', url: '/api/undefined' }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['content-length'], '0')
+    t.strictEqual(res.body, '')
+  })
+})


### PR DESCRIPTION
As described in [#2619](https://github.com/fastify/fastify/issues/2619)

The PR fixes bad handling of `undefined` values, preserving the explicit send of `null` as a response. i.e. `res.status(200).send(null)`.

Checklist
- [x] run npm run test
- [x] tests are included
- [ ] documentation is changed or added